### PR TITLE
Add validation for sudo rules to make it safer

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -32,4 +32,10 @@ define sudo::conf (
     source  => $source,
     content => $content_real,
   }
+  if versioncmp($::puppetversion, '3.5') >= 0 {
+    File["${name_real}"] { validate_cmd => "${sudo::sudo_check_cmd} %" }
+  }
+  else {
+    validate_cmd($content_real, "${sudo::sudo_check_cmd}", "Failed to validate sudoers content with ${sudo::sudo_check_cmd}")
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class sudo (
   $package_ensure        = $sudo::params::package_ensure,
   $sudoers_file_path     = $sudo::params::sudoers_file_path,
   $sudoersd_path         = $sudo::params::sudoersd_path,
+  $sudo_check_cmd        = $sudo::params::sudo_check_cmd,
   $sudoers_file_content  = undef,
   $defaults_hash         = undef,
   $confs_hash            = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class sudo::params {
   $package_ensure         = 'present'
   $sudoers_file_path      = '/etc/sudoers'
   $sudoersd_path          = '/etc/sudoers.d'
+  $sudo_check_cmd         = '/usr/sbin/visudo -c -f'
 
   case $::osfamily {
     debian: {


### PR DESCRIPTION
Based on a solution from
http://stackoverflow.com/questions/27071642/validate-cmd-in-puppet-supporting-older-versions
