### PR TITLE
Don't raise error if defaults_hash undefined.

### DIFF
--- a/templates/defaults.erb
+++ b/templates/defaults.erb
@@ -1,4 +1,4 @@
-<%- @defaults_hash.sort.each do |key, value| -%>
+<%- (@defaults_hash || {}).sort.each do |key, value| -%>
   <%- if value.class == TrueClass -%>
     Defaults <%= key %>
   <%- elsif value.class == FalseClass -%>


### PR DESCRIPTION
Small change to the template so we don't end up calling sort on nil.